### PR TITLE
Get URL of Gateway in Frontend from environment variable

### DIFF
--- a/ehrenamt-justiz-backend/src/main/resources/application.yml
+++ b/ehrenamt-justiz-backend/src/main/resources/application.yml
@@ -94,6 +94,6 @@ info:
 # Define eai
 ewo:
   eai:
-    basepath: /api/personeninfo
+    basepath: /public/eai/api/personeninfo
     connecttimeout: 15000
     readtimeout: 15000

--- a/ehrenamt-justiz-frontend/.env
+++ b/ehrenamt-justiz-frontend/.env
@@ -4,4 +4,4 @@ VITE_AD2IMAGE_URL="https://mucatar.muenchen.de/"
 # https://github.com/it-at-m/appswitcher-server or disable appswitcher with setting "" as value
 VITE_APPSWITCHER_URL="http://localhost:8084" # appswitcher of local stack
 # VITE_APPSWITCHER_URL="" # to disable appswitcher
-VITE_VUE_APP_API_URL=http://refarch-gateway-dev.ehrju.svc.cluster.local:8080
+VITE_VUE_APP_API_URL=http://localhost:8083


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- ...
- ...

## Reference

Issue: #XXX

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Added meaningful PR title and list of changes in the description



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend API base path to use a public endpoint (/public/eai/api/personeninfo), ensuring requests route through the new gateway path.
  * Switched the frontend’s API target to a local gateway (http://localhost:8083) for local environment usage, replacing the previous remote service target.
  * No feature behavior changes; only connection endpoints were adjusted. End users should experience uninterrupted access, while local runs now connect to the local gateway by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->