### PR TITLE
Username extraction claim configurable- #1740

### DIFF
--- a/ehrenamt-justiz-backend/src/main/java/de/muenchen/ehrenamtjustiz/backend/configuration/filter/RequestResponseLoggingFilter.java
+++ b/ehrenamt-justiz-backend/src/main/java/de/muenchen/ehrenamtjustiz/backend/configuration/filter/RequestResponseLoggingFilter.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.springframework.boot.web.servlet.FilterRegistration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
@@ -18,7 +19,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * This filter logs the username for requests.
+ * This filter logs the username from requests using the {@link AuthUtils} bean.
  */
 @Profile("!no-security")
 @Component
@@ -30,6 +31,7 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
     private static final List<String> CHANGING_METHODS = List.of(HttpMethod.POST.name(), HttpMethod.PUT.name(), HttpMethod.PATCH.name(),
             HttpMethod.DELETE.name());
 
+    private final AuthUtils authUtils;
     private final SecurityProperties securityProperties;
 
     /**
@@ -56,12 +58,12 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
      * {@inheritDoc}
      */
     @Override
-    protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain)
+    protected void doFilterInternal(final @NonNull HttpServletRequest request, final @NonNull HttpServletResponse response, final FilterChain filterChain)
             throws ServletException, IOException {
         filterChain.doFilter(request, response);
         if (checkForLogging(request)) {
             log.info("User {} executed {} on URI {} with http status {}",
-                    AuthUtils.getUsername(),
+                    authUtils.getUsername(),
                     request.getMethod(),
                     request.getRequestURI(),
                     response.getStatus());

--- a/ehrenamt-justiz-backend/src/main/java/de/muenchen/ehrenamtjustiz/backend/configuration/security/SecurityProperties.java
+++ b/ehrenamt-justiz-backend/src/main/java/de/muenchen/ehrenamtjustiz/backend/configuration/security/SecurityProperties.java
@@ -29,6 +29,12 @@ public class SecurityProperties {
     @NotBlank private String clientId;
 
     /**
+     * Name of the JWT claim that contains the username.
+     * Defaults to "preferred_username" if not configured.
+     */
+    @NotBlank private String usernameClaim = "preferred_username";
+
+    /**
      * URI of the endpoint used for fetching permissions,
      * see also {@link KeycloakPermissionsAuthoritiesConverter}.
      */

--- a/ehrenamt-justiz-backend/src/main/java/de/muenchen/ehrenamtjustiz/backend/security/AuthUtils.java
+++ b/ehrenamt-justiz-backend/src/main/java/de/muenchen/ehrenamtjustiz/backend/security/AuthUtils.java
@@ -1,35 +1,38 @@
 package de.muenchen.ehrenamtjustiz.backend.security;
 
+import de.muenchen.ehrenamtjustiz.backend.configuration.security.SecurityProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
+import org.springframework.stereotype.Component;
+
 /**
- * Utilities for authentication data.
+ * Utility bean for authentication related data.
  */
-public final class AuthUtils {
+@Component
+@Profile("!no-security")
+@RequiredArgsConstructor
+public class AuthUtils {
 
     public static final String NAME_UNAUTHENTICATED_USER = "unauthenticated";
 
-    private static final String TOKEN_USER_NAME = "preferred_username";
-
-    private AuthUtils() {
-    }
+    private final SecurityProperties securityProperties;
 
     /**
-     * Extracts the username from the existing Spring Security Context via
+     * Extracts the user name from the existing Spring Security Context via
      * {@link SecurityContextHolder}.
      *
      * @return the username or an "unauthenticated" if no {@link Authentication} exists
      */
-    public static String getUsername() {
+    public String getUsername() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication instanceof JwtAuthenticationToken) {
-            final JwtAuthenticationToken jwtAuth = (JwtAuthenticationToken) authentication;
-            return (String) jwtAuth.getTokenAttributes().getOrDefault(TOKEN_USER_NAME, null);
-        } else if (authentication instanceof UsernamePasswordAuthenticationToken) {
-            final UsernamePasswordAuthenticationToken usernameAuth = (UsernamePasswordAuthenticationToken) authentication;
+        if (authentication instanceof JwtAuthenticationToken jwtAuth) {
+            return (String) jwtAuth.getTokenAttributes().get(securityProperties.getUsernameClaim());
+        } else if (authentication instanceof UsernamePasswordAuthenticationToken usernameAuth) {
             return usernameAuth.getName();
         } else {
             return NAME_UNAUTHENTICATED_USER;

--- a/ehrenamt-justiz-backend/src/test/java/de/muenchen/ehrenamtjustiz/backend/security/AuthUtilsTest.java
+++ b/ehrenamt-justiz-backend/src/test/java/de/muenchen/ehrenamtjustiz/backend/security/AuthUtilsTest.java
@@ -1,0 +1,95 @@
+package de.muenchen.ehrenamtjustiz.backend.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import de.muenchen.ehrenamtjustiz.backend.configuration.security.SecurityProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+@ExtendWith(MockitoExtension.class)
+class AuthUtilsTest {
+
+    private static final String USERNAME_CLAIM = "preferred_username";
+
+    @Mock
+    private SecurityProperties securityProperties;
+
+    @InjectMocks
+    private AuthUtils authUtils;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void givenJwtWithUsernameClaim_thenReturnUsername() {
+        // given
+        when(securityProperties.getUsernameClaim()).thenReturn(USERNAME_CLAIM);
+        final Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .claim(USERNAME_CLAIM, "john.doe")
+                .build();
+        final JwtAuthenticationToken authentication = new JwtAuthenticationToken(jwt);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when
+        final String username = authUtils.getUsername();
+
+        // then
+        assertThat(username).isEqualTo("john.doe");
+    }
+
+    @Test
+    void givenJwtWithoutUsernameClaim_thenReturnUnauthenticatedUser() {
+        // given
+        when(securityProperties.getUsernameClaim()).thenReturn(USERNAME_CLAIM);
+        final Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .claims(claims -> claims.put("other", "value"))
+                .build();
+        final JwtAuthenticationToken authentication = new JwtAuthenticationToken(jwt);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when
+        final String username = authUtils.getUsername();
+
+        // then
+        assertThat(username).isNull();
+    }
+
+    @Test
+    void givenUsernamePasswordAuthentication_thenReturnUsername() {
+        // given
+        final UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken("jane.doe", "password");
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // when
+        final String username = authUtils.getUsername();
+
+        // then
+        assertThat(username).isEqualTo("jane.doe");
+    }
+
+    @Test
+    void givenNoAuthentication_thenReturnUnauthenticatedUser() {
+        // given
+        SecurityContextHolder.clearContext();
+
+        // when
+        final String username = authUtils.getUsername();
+
+        // then
+        assertThat(username).isEqualTo(AuthUtils.NAME_UNAUTHENTICATED_USER);
+    }
+
+}


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- ...
- ...

## Reference

Issue: #XXX

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Added meaningful PR title and list of changes in the description



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved username detection during request logging.
  * Username claims can now be configured instead of relying on a fixed claim name.
  * Preserved fallback handling for authenticated and unauthenticated requests.

* **Documentation**
  * Added documentation describing the configurable username claim and its default value.

* **Tests**
  * Added coverage for JWT, token-based, and unauthenticated username scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->